### PR TITLE
fix(api): Victoria Briefing — Synthesia v2 schema + Supabase audio upload

### DIFF
--- a/server/routers/externalIntegrations.router.ts
+++ b/server/routers/externalIntegrations.router.ts
@@ -476,11 +476,10 @@ export const synthesiaRouter = router({
         test: z.boolean().default(true),
         input: z.array(
           z.object({
-            avatarId: z.string().optional(),
-            script: z.string().min(1),
+            avatar: z.string(),
+            scriptText: z.string().min(1),
             voiceId: z.string().optional(),
-            backgroundId: z.string().optional(),
-            backgroundColor: z.string().optional(),
+            background: z.string().optional(),
           })
         ),
       })
@@ -489,7 +488,18 @@ export const synthesiaRouter = router({
       const { synthesiaService } = await import(
         "../services/synthesia.service"
       );
-      return synthesiaService.createVideo(input);
+      // This is a generic passthrough; we must remap the input fields
+      // to match the new Synthesia v2 schema.
+      const remappedInput = {
+        ...input,
+        input: input.input.map((i) => ({
+          avatar: i.avatarId ?? "anna_costume1_cameraA",
+          scriptText: i.script,
+          background: i.backgroundColor ?? i.backgroundId ?? "off_white",
+          voiceId: i.voiceId,
+        })),
+      };
+      return synthesiaService.createVideo(remappedInput);
     }),
 });
 

--- a/server/routers/externalIntegrations.router.ts
+++ b/server/routers/externalIntegrations.router.ts
@@ -488,18 +488,8 @@ export const synthesiaRouter = router({
       const { synthesiaService } = await import(
         "../services/synthesia.service"
       );
-      // This is a generic passthrough; we must remap the input fields
-      // to match the new Synthesia v2 schema.
-      const remappedInput = {
-        ...input,
-        input: input.input.map((i) => ({
-          avatar: i.avatarId ?? "anna_costume1_cameraA",
-          scriptText: i.script,
-          background: i.backgroundColor ?? i.backgroundId ?? "off_white",
-          voiceId: i.voiceId,
-        })),
-      };
-      return synthesiaService.createVideo(remappedInput);
+      // Fields already match the v2 schema — pass through directly.
+      return synthesiaService.createVideo(input);
     }),
 });
 

--- a/server/routers/victoriaBriefing.router.ts
+++ b/server/routers/victoriaBriefing.router.ts
@@ -333,11 +333,10 @@ export const victoriasBriefRouter = router({
           test: true, // Use test mode to avoid billing during development
           input: [
             {
-              // Talia (EXPRESS-1) — valid Synthesia stock avatar ID
-              avatarId:
-                input.avatarId ?? "b3d74452-7011-4e8e-b3bf-12f7406f8f22",
-              script: script.slice(0, 1500), // Synthesia limit
-              backgroundColor: "#0f172a",
+              // anna_costume1_cameraA — confirmed working Synthesia stock avatar
+              avatar: input.avatarId ?? "anna_costume1_cameraA",
+              scriptText: script.slice(0, 1500), // Synthesia v2: scriptText not script
+              background: "off_white", // Synthesia v2: background not backgroundColor
             },
           ],
         });
@@ -429,6 +428,40 @@ export const victoriasBriefRouter = router({
         }
 
         const buffer = await response.arrayBuffer();
+
+        // Upload to Supabase Storage so mobile browsers can play a real HTTPS URL
+        // (iOS Safari cannot play data: URIs in <audio> elements)
+        const supabaseUrl = process.env.SUPABASE_URL;
+        const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+        if (supabaseUrl && supabaseKey) {
+          try {
+            const fileName = `audio/victoria-briefing-${Date.now()}.mp3`;
+            const uploadRes = await fetch(
+              `${supabaseUrl}/storage/v1/object/documents/${fileName}`,
+              {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${supabaseKey}`,
+                  apikey: supabaseKey,
+                  "Content-Type": "audio/mpeg",
+                },
+                body: buffer,
+              }
+            );
+            if (uploadRes.ok) {
+              const publicUrl = `${supabaseUrl}/storage/v1/object/public/documents/${fileName}`;
+              return {
+                success: true,
+                audioUrl: publicUrl,
+                message: "Audio generated",
+              };
+            }
+          } catch {
+            // Fall through to base64 fallback
+          }
+        }
+
+        // Fallback: base64 data URI (works on desktop, may fail on iOS)
         const base64 = Buffer.from(buffer).toString("base64");
         return {
           success: true,

--- a/server/services/synthesia.service.ts
+++ b/server/services/synthesia.service.ts
@@ -28,25 +28,26 @@ export interface SynthesiaVideo {
   updatedAt: string;
 }
 
+/**
+ * Synthesia v2 API — correct field names:
+ *   input[].avatar       (not avatarId)
+ *   input[].scriptText   (not script)
+ *   input[].background   (not backgroundColor / backgroundId)
+ */
 export interface CreateVideoOptions {
   title: string;
   description?: string;
   visibility?: "public" | "private";
   test?: boolean;
   input: Array<{
-    avatarId?: string;
-    avatarSettings?: {
-      horizontalAlign?: "left" | "center" | "right";
-      scale?: number;
-      style?: "rectangular" | "circle" | "square";
-      seamless?: boolean;
-    };
-    backgroundId?: string;
-    backgroundColor?: string;
+    /** Synthesia avatar ID, e.g. "anna_costume1_cameraA" */
+    avatar: string;
+    /** The spoken text for this slide */
+    scriptText: string;
+    /** Background ID or colour string, e.g. "off_white" or "#0f172a" */
+    background?: string;
     voiceId?: string;
     voiceStyle?: string;
-    script: string;
-    scriptType?: "text" | "ssml";
   }>;
 }
 


### PR DESCRIPTION
## Summary

Fixes the two remaining Victoria Briefing failures.

### 1. Synthesia Video — 400 ValidationError (wrong field names)

The Synthesia v2 API rejects payloads using old v1 field names. Corrected:

| Old (v1) | New (v2) |
|---|---|
| `avatarId` | `avatar` |
| `script` | `scriptText` |
| `backgroundColor` | `background` |

**Files changed:**
- `server/services/synthesia.service.ts` — updated `CreateVideoOptions` interface
- `server/routers/victoriaBriefing.router.ts` — updated `generateVideo` mutation
- `server/routers/externalIntegrations.router.ts` — updated `synthesiaRouter.createVideo` zod schema

### 2. ElevenLabs Audio — iOS Safari cannot play `data:` URIs

iOS Safari refuses to play `data:audio/mpeg;base64,...` URIs. The fix uploads the MP3 to Supabase Storage and returns a real HTTPS URL. A base64 fallback is retained for environments without Supabase env vars.

**Files changed:**
- `server/routers/victoriaBriefing.router.ts` — updated `generateAudio` mutation

## Risk

Low — minimal, targeted changes. No refactoring. No schema migrations.